### PR TITLE
Support WR841N V14

### DIFF
--- a/tpconf_bin_xml.py
+++ b/tpconf_bin_xml.py
@@ -28,7 +28,7 @@ from struct import pack, pack_into, unpack_from
 
 from Cryptodome.Cipher import DES # apt install python3-pycryptodome (OR: pip install pycryptodomex)
 
-__version__ = '0.2.9'
+__version__ = '0.2.10'
 
 def compress(src, skiphits=False):
     '''Compress buffer'''
@@ -242,6 +242,17 @@ if __name__ == '__main__':
                 src += b'\0'
             md5hash = md5(src).digest()
             dst = md5hash + src
+        elif b'WR841N v14' in src: # lock to v14, seems varied between versions otherwise
+            print('OK: WR841N v14 XML file - compressing, hashing and encrypting…')
+            if packint == '>I':
+                print('WARNING: wrong endianess, automatically setting little. (see -h)')
+                packint = '<I'
+            size, dst = compress(src, False) 
+            # seems like the router wants compessed data multiple of 8  
+            if len(dst) & 7:
+                dst += b'\0' * (8 - (len(dst) & 7))         
+            md5hash = md5(dst).digest()
+            dst = md5hash + bytes(dst)
         else:
             skiphits = False
             if b'Archer' in src:


### PR DESCRIPTION
Attempt to redeem myself after last attempt.

Support TP link WR841N only v14. Seems that between each version, the code can change significantly and can't guarantee that this patch will work on older models. 

The router also wants padding to be performed before the MD5 is calculated, otherwise the config file will fail to upload. Confirmed that it indeed does expect the padding during unpacking otherwise the hashes don't match and this is reliable with varying sizes of input.  

Not seen v14 in big endian either.