### PR TITLE
Add support for XZ005-G6(UN) V1.0 XPON SFU

### DIFF
--- a/tpconf_bin_xml.py
+++ b/tpconf_bin_xml.py
@@ -30,6 +30,10 @@ from Cryptodome.Cipher import DES # apt install python3-pycryptodome (OR: pip in
 
 __version__ = '0.2.11'
 
+KEYS = {
+    'default': b'\x47\x8D\xA5\x0B\xF9\xE3\xD2\xCF',
+}
+
 def compress(src, skiphits=False):
     '''Compress buffer'''
     # Make sure last byte is NULL
@@ -221,7 +225,7 @@ if __name__ == '__main__':
 
     packint = '<I' if args.littleendian else '>I'
 
-    key = b'\x47\x8D\xA5\x0B\xF9\xE3\xD2\xCF'
+    key = KEYS['default']
     crypto = DES.new(key, DES.MODE_ECB)
 
     with open(args.infile, 'rb') as f:

--- a/tpconf_bin_xml.py
+++ b/tpconf_bin_xml.py
@@ -251,7 +251,7 @@ if __name__ == '__main__':
         elif b'WR841N v14' in src: # lock to v14, seems varied between versions otherwise
             print('OK: WR841N v14 XML file - compressing, hashing and encrypting…')
             if packint == '>I':
-                print('WARNING: wrong endianess, automatically setting little. (see -h)')
+                print('WARNING: wrong endianness, automatically setting little. (see -h)')
                 packint = '<I'
             size, dst = compress(src, False)
             # seems like the router wants compessed data multiple of 8

--- a/tpconf_bin_xml.py
+++ b/tpconf_bin_xml.py
@@ -28,7 +28,7 @@ from struct import pack, pack_into, unpack_from
 
 from Cryptodome.Cipher import DES # apt install python3-pycryptodome (OR: pip install pycryptodomex)
 
-__version__ = '0.2.11'
+__version__ = '0.2.12'
 
 KEYS = {
     'default': b'\x47\x8D\xA5\x0B\xF9\xE3\xD2\xCF',


### PR DESCRIPTION
### Context

Except for the different DES key used in this model, all the existing code for packing and unpacking works fine. Besides having a different "base" key, it's further xor'ed with device's product ID (0x1c796e01), meaning it works only for this exact model/variant (unless TP-Link reuses the base key, algo and product ID).

Some of these devices are known to have per-country variants, but couldn't find any other for this specific one. It's tagged "UN" everywhere - despite using "EU" inside XMLs - and been acquired in Brazil. So might it be **UN**iversal?

No easy way has been found to get the product ID so one could confirm it's compatible with this patch; like from web GUI. Seems buried only inside the filesystem and XMLs. In case one got a working firmware update for the hardware at hand - sharing the same format -, it can be read from the file at offset 0x34 (big endian): 0x1c796e01 expected.

Further info and research (in progress) can be found [at this wiki page](https://www.tripleoxygen.net/wiki/ont/tplink/xz005-g6-un-v1) (Portuguese only, sorry).

### About the PR

Since multiple keys wasn't expected in code, did some quick juggling around so this could be implemented. Also, based on previous commits and general code idea, it tries to keep the tool mostly "automagic", working out the available keys as needed and not adding new command line options.

As this new key is based on product ID, I think it's safe to "lock" it under a specific/restrict identifier/model/variant.

Unfortunately I don't have config samples from other devices to thoroughly test after these changes. As for this hardware, sample bin + relevant XML for eventual testing is attached and available [at this link](https://tripleoxygen.net/files/devices/tplink/xz005-g6-un-v1/configs/conf.sample.zip) if needed (it has been unpacked, cleaned from unique info, repacked and tested on device).


Regards!

[conf.sample.zip](https://github.com/user-attachments/files/17527207/conf.sample.zip)