### PR TITLE
Add EX530v v1.0 key, encode branch, and raise config size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Simple command line utility to convert TP-Link modem/router backup config files 
 - conf.bin ➡ decrypt, md5hash and uncompress ➡ conf.xml
 - conf.xml ➡ compress, md5hash and encrypt ➡ conf.bin
 
-*Should work for TP-Link models: TD-W8970, TD-W8980, TD-W9970, TD-W9980 (thanks d3dave), Archer VR900, C2, C20 and C60 / AC1350 (d3dave), TL-WR841N (thanks odolezal), WR841N V14 (thanks mcoops), XZ005-G6 (thanks tripleoxygen), Archer AC3150 v2 (thanks borodean!), VC220-G3u (Thanks cpatulea), EX230V V1.0 (Thanks jqssun).*<br>
+*Should work for TP-Link models: TD-W8970, TD-W8980, TD-W9970, TD-W9980 (thanks d3dave), Archer VR900, C2, C20 and C60 / AC1350 (d3dave), TL-WR841N (thanks odolezal), WR841N V14 (thanks mcoops), XZ005-G6 (thanks tripleoxygen), Archer AC3150 v2 (thanks borodean!), VC220-G3u (Thanks cpatulea), EX230V V1.0 (Thanks jqssun), EX530v V1.0 (Thanks guness).*<br>
+*Note: the EX530v v1.0 is little-endian — decode with `-l`.*<br>
 *May or may not work with other TP-Link modem/routers, newer firmwares.*
 
 ## Getting Started

--- a/tpconf_bin_xml.py
+++ b/tpconf_bin_xml.py
@@ -37,7 +37,12 @@ KEYS = {
     'vc220-g3u': b'\x40\xec\xc4\x3a\xca\x0a\x1d\xfe',
     'bsn3000x-v1': b'\x44\xBF\xC3\x3B\x9D\x0C\x1D\xFD',
     'ex221-g5v1': b'\x45\xe8\x90\x6f\x9a\x0a\x1d\xfe',
+    'ex530v-v1': b'\x40\xba\xc6\x6c\xca\x5a\x1c\xfe',
 }
+
+# Largest plausible config size; the EX530v v1.0 XML is ~135 KiB, which exceeded
+# the previous 0x20000 limit and was rejected as "too large".
+MAX_SIZE = 0x40000
 
 def compress(src, skiphits=False):
     '''Compress buffer'''
@@ -206,9 +211,9 @@ def verify_ac3150_v2(src):
 
 def check_size_endianness(src):
     global packint
-    if unpack_from(packint, src)[0] > 0x20000:
+    if unpack_from(packint, src)[0] > MAX_SIZE:
         packint = '<I' if packint == '>I' else '>I'
-        if unpack_from(packint, src)[0] > 0x20000:
+        if unpack_from(packint, src)[0] > MAX_SIZE:
             print('ERROR: compressed size too large for a TP-Link config file!')
             exit()
         print('WARNING: wrong endianness, automatically switching. (see -h)')
@@ -229,7 +234,7 @@ if __name__ == '__main__':
                         help='Overwrite output file')
     args = parser.parse_args()
 
-    if path.getsize(args.infile) > 0x20000:
+    if path.getsize(args.infile) > MAX_SIZE:
         print('ERROR: Input file too large for a TP-Link config file!')
         exit()
     if not args.overwrite and path.exists(args.outfile):
@@ -292,6 +297,15 @@ if __name__ == '__main__':
             if packint == '<I':
                 print('WARNING: wrong endianness, automatically setting big. (see -h)')
                 packint = '>I'
+            size, dst = compress(src, False)
+            md5hash = md5(dst).digest()
+            dst = md5hash + bytes(dst)
+        elif b'EX530v' in src: # EX530v v1.0 (ISP-customized), little-endian
+            print('OK: EX530v XML file - compressing, hashing and encrypting…')
+            key = KEYS['ex530v-v1']
+            if packint == '>I':
+                print('WARNING: wrong endianness, automatically setting little. (see -h)')
+                packint = '<I'
             size, dst = compress(src, False)
             md5hash = md5(dst).digest()
             dst = md5hash + bytes(dst)


### PR DESCRIPTION
Adds support for the **TP-Link EX530v v1.0**, an ISP-customized VDSL gateway (seen on Turkcell Superonline in Turkey). None of the six existing keys decrypt its `conf.bin`.

Tested against a real backup from an EX530v v1.0, firmware `EX530v-v1.0_250415_2424`.

### Changes

**1. New key `ex530v-v1` = `40 BA C6 6C CA 5A 1C FE`**

Recovered by brute force rather than firmware extraction — TP-Link does not publish firmware for this ISP-locked model. The search was made tractable by the structure the existing ISP keys already share (`byte6 == 0x1D`, `byte7 ∈ {FE,FD}`, `byte0 ∈ 0x40..0x47`) plus the fact that DES ignores each key byte's LSB as a parity bit, which cuts the space 32×.

It is confirmed by the config's own MD5 self-check, and the decrypted XML contains `<X_TP_DeviceModel val=EX530v(EU)/>`. Note this is the parity-normalized form; TP-Link's original is presumably `40 BB C7 6D CA 5B 1D FE`, which DES treats identically.

**2. Encode branch for `EX530v`**

Without it, `xml -> bin` silently falls through to the `default` key and produces a file the router will reject. Mirrors the existing XZ005-G6 branch, including forcing little-endian.

**3. `MAX_SIZE = 0x40000`, replacing three hardcoded `0x20000` limits**

This is the one change that affects other models, so flagging it explicitly. The EX530v's uncompressed XML is 138160 bytes (~135 KiB), over the old 0x20000 ceiling, so decoding failed twice: first in the input-size guard when re-encoding, then in `check_size_endianness` with *"compressed size too large for a TP-Link config file!"*.

The limit also serves as the endianness heuristic, so raising it does weaken that slightly — it now only auto-flips when a byteswapped size exceeds 256 KiB rather than 128 KiB. In practice a wrong-endian read is off by orders of magnitude (this file reads as 2954560000 big-endian vs 138160 little-endian), so detection still works. Happy to bump it to a smaller value, or gate it per-model, if you'd prefer something more conservative.

### Verification

```
$ ./tpconf_bin_xml.py -l conf.bin conf.xml
OK: appears your device uses little-endian.
OK: BIN file decrypted, MD5 hash verified, uncompressing…
Done.
```

Round-trip `conf.bin -> conf.xml -> conf.bin' -> conf.xml'` produces byte-identical XML. The re-encoded `.bin` is smaller than the original (21152 vs 21904 bytes) because this compressor packs tighter than the router's, which is expected and also true of the already-supported models.

**Caveat:** I have not restored a re-encoded file to the device, so the encode path is verified only by round-trip, not by the router accepting it.

### Note for EX530v users

The device is little-endian, so decoding needs `-l`. README updated accordingly.
